### PR TITLE
Rollback to v1.1.2

### DIFF
--- a/Formula/nexttrace.rb
+++ b/Formula/nexttrace.rb
@@ -1,15 +1,15 @@
 class Nexttrace < Formula
     desc "An open source visual route tracking CLI tool"
     homepage "https://mtr.moe"
-    version "v1.1.7-1"
-    url "https://github.com/xgadget-lab/nexttrace/archive/refs/tags/v1.1.7-1.tar.gz"
-    sha256 "1c937a9f7c2f1d4a3e71e63db2929a5b24d438c63efd9715b00277f1b3add4cb"
+    version "v1.1.2"
+    url "https://api.github.com/repos/nxtrace/Ntrace-core/tarball/v1.1.2"
+    sha256 "6119625c664bc227cdc3726dd4d0a27c5016f752b4958235dfc40ebe9ba4ec39"
     license "GPL-3.0"
 
     depends_on "go" => :build
   
     def install
-      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/config.Version=v1.1.7-1' -s -w")
+      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/printer.version=v1.1.2' -s -w")
     end
   
     test do

--- a/genFormula.sh
+++ b/genFormula.sh
@@ -1,12 +1,13 @@
 # !/bin/bash
-version="$(curl -sL https://api.github.com/repos/sjlleo/nexttrace-core/releases/latest | jq ".name")"
-url="https://github.com/xgadget-lab/nexttrace/archive/refs/tags/${version:1:$((${#version} - 1 - 1))}.tar.gz"
-sha256="$(curl -sL ${url} | sha256sum | cut -f1 -d' ')"
+release="$(curl -sL https://api.github.com/repos/xgadget-lab/nexttrace/releases/latest)"
+version="$(jq -r ".name" <<< "$release")"
+url="$(jq -r ".tarball_url" <<< "$release")"
+sha256="$(curl -sL "$url" | sha256sum | cut -f1 -d' ')"
 cat >Formula/nexttrace.rb <<EOF
 class Nexttrace < Formula
     desc "An open source visual route tracking CLI tool"
     homepage "https://mtr.moe"
-    version ${version}
+    version "${version}"
     url "${url}"
     sha256 "${sha256}"
     license "GPL-3.0"
@@ -14,7 +15,7 @@ class Nexttrace < Formula
     depends_on "go" => :build
   
     def install
-      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/config.Version=${version:1:$((${#version} - 1 - 1))}' -s -w")
+      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/config.Version=${version}' -s -w")
     end
   
     test do

--- a/genFormula.sh
+++ b/genFormula.sh
@@ -1,5 +1,5 @@
 # !/bin/bash
-version="$(curl -s https://api.github.com/repos/sjlleo/nexttrace-core/releases/latest | jq ".name")"
+version="$(curl -sL https://api.github.com/repos/sjlleo/nexttrace-core/releases/latest | jq ".name")"
 url="https://github.com/xgadget-lab/nexttrace/archive/refs/tags/${version:1:$((${#version} - 1 - 1))}.tar.gz"
 sha256="$(curl -sL ${url} | sha256sum | cut -f1 -d' ')"
 cat >Formula/nexttrace.rb <<EOF

--- a/genFormula.sh
+++ b/genFormula.sh
@@ -15,7 +15,7 @@ class Nexttrace < Formula
     depends_on "go" => :build
   
     def install
-      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/config.Version=${version}' -s -w")
+      system "go", "build", *std_go_args(ldflags: "-X 'github.com/xgadget-lab/nexttrace/printer.version=${version}' -s -w")
     end
   
     test do


### PR DESCRIPTION
Current behaviour:

```
==> Fetching xgadget-lab/nexttrace/nexttrace
==> Downloading https://github.com/xgadget-lab/nexttrace/archive/refs/tags/v1.1.7-1.tar.gz
==> Downloading from https://codeload.github.com/nxtrace/Ntrace-core/tar.gz/refs/tags/v1.1.7-1
Error: SHA256 mismatch
Expected: 1c937a9f7c2f1d4a3e71e63db2929a5b24d438c63efd9715b00277f1b3add4cb
  Actual: 506db2d92404b8923dd3caaaeab2f3ba2b828e018d3a9721419802a17e828057
    File: /Users/wangxinhe/Library/Caches/Homebrew/downloads/eb8fdf372382a4b3af5f8726c793d486953e15789270e14a38a1926ad6571b43--Ntrace-core-1.1.7-1.tar.gz
To retry an incomplete download, remove the file above.
```
